### PR TITLE
Adding a proper License file and fixing a typo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Muhammad Ahmad Khan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Yajirobe The Bot is a RAG (Retrieval-Augmented Generation) chatbot built using Streamlit, Ollama, and scikit-learn. It allows users to upload PDF documents, extract text, and ask questions related to the document. The chatbot finds relevant context from the document and generates responses using a locally installed LLM.
 
 ## Features
+
 - 📂 Upload and process PDF files
 - 🔎 Retrieve relevant sentences from the document
 - 🤖 Generate responses based on context using a local LLM
@@ -28,10 +29,11 @@ Yajirobe The Bot is a RAG (Retrieval-Augmented Generation) chatbot built using S
    ```
 4. Run the Streamlit app:
    ```sh
-   streamlit run app.py
+   streamlit run main.py
    ```
 
 ## Dependencies
+
 - `streamlit`
 - `ollama`
 - `PyPDF2`
@@ -39,6 +41,7 @@ Yajirobe The Bot is a RAG (Retrieval-Augmented Generation) chatbot built using S
 - `nltk`
 
 ## Usage
+
 1. Open the app in your browser after running the script. [You can do that by typing "streamlit run <filename>.py" in the terminal of your code editor]
 2. Upload a PDF file from the sidebar.
 3. Ask questions about the document using the chat input.
@@ -46,15 +49,18 @@ Yajirobe The Bot is a RAG (Retrieval-Augmented Generation) chatbot built using S
 5. Download the chat history if needed.
 
 ## To-Do
+
 - [ ] Improve response accuracy by fine-tuning vectorization
 - [ ] Add multi-PDF support
 - [ ] Implement UI enhancements
 - [ ] Optimize memory usage for large documents
 
 ## License
+
 This project is licensed under the MIT License. Feel free to modify and use it as needed.
 
 ## Author
+
 **Muhammad Ahmad Khan**
 
 Happy coding!


### PR DESCRIPTION
If you have decided on a LICENSE for your project add an appropriate LICENSE file for it in the repo that let's it be recognized by Github.

Also there was a typo in the README saying you should execute `streamlit run app.py` when it should be `streamlit run main.py`